### PR TITLE
changed hemoglobin regex to exclude HBEGF and HBS1L

### DIFF
--- a/MORESCA/analysis_steps.py
+++ b/MORESCA/analysis_steps.py
@@ -99,7 +99,7 @@ def quality_control(
 
     adata.var["mt"] = adata.var_names.str.contains("(?i)^MT-")
     adata.var["rb"] = adata.var_names.str.contains(("(?i)^RP[SL]"))
-    adata.var["hb"] = adata.var_names.str.contains(("(?i)^HB[^(P)]"))
+    adata.var["hb"] = adata.var_names.str.contains(("(?i)^HB(?!EGF|S1L|P1).+"))
 
     sc.pp.calculate_qc_metrics(
         adata,


### PR DESCRIPTION
The current regex for hemoglobin genes matches the non-hemoglobin genes HBEGF and HBS1L. This commit fixes that bug by introducing a new regex that specifically excludes these two genes as well as HBP1.