### PR TITLE
Add explicit specification of code location for setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,3 +107,10 @@ skip-magic-trailing-comma= true
 
 # Like Black, automatically detect the appropriate line ending.
 line-ending = "auto"
+
+#SOURCE: https://stackoverflow.com/a/76739181
+[tool.setuptools.packages.find]
+where = ["."]  # list of folders that contain the packages (["."] by default)
+include = ["MORESCA"]  # package names should match these glob patterns (["*"] by default)
+exclude = []  # exclude packages matching these glob patterns (empty by default)
+namespaces = false  # to disable scanning PEP 420 namespaces (true by default)


### PR DESCRIPTION
Fixes the error

```
× Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      error: Multiple top-level packages discovered in a flat-layout: ['data', 'MORESCA'].
      
      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.
      
      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:
      
      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names
      
      To find more information, look for "package discovery" on setuptools docs.
```

when installing on some systems.